### PR TITLE
feat(examples): Add practical example for Gemini with LangChain

### DIFF
--- a/notebooks/04-llm.ipynb
+++ b/notebooks/04-llm.ipynb
@@ -1,0 +1,161 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1463c558",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "from dotenv import load_dotenv\n",
+    "load_dotenv()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65838c70",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "E0000 00:00:1759929956.433159  892730 alts_credentials.cc:93] ALTS creds ignored. Not running on GCP and untrusted ALTS is not enabled.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "¡Hola! Estoy bien, gracias por preguntar. ¿Y tú? ¿Cómo estás hoy?\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_google_genai import ChatGoogleGenerativeAI\n",
+    "\n",
+    "# Asegúrate de tener tu API key de Google configurada en tus variables de entorno\n",
+    "# con el nombre GOOGLE_API_KEY.\n",
+    "\n",
+    "# Inicializa el modelo de Gemini, por ejemplo, \"gemini-2.0-flash-lite-001\"\n",
+    "gemini_lite = ChatGoogleGenerativeAI(model=\"gemini-2.0-flash-lite-001\", temperature=0)\n",
+    "\n",
+    "# Envía la pregunta al modelo\n",
+    "response = gemini_lite.invoke(\"Hola como estas?\")\n",
+    "response.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7242e699",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Te llamas Juan. 😊\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain_core.messages import AIMessage, HumanMessage, SystemMessage\n",
+    "\n",
+    "msg_1 = SystemMessage(content=\"You are a helpful assistant that talks in spanish\")\n",
+    "msg_2 = HumanMessage(content=\"Me llamo Juan\")\n",
+    "msg_3 = AIMessage(content=\"Hola Juan, como estas?\")\n",
+    "msg_4 = HumanMessage(content=\"Como me llamo?\")\n",
+    "history = [msg_1, msg_2, msg_3, msg_4]\n",
+    "response = gemini_lite.invoke(history)\n",
+    "response.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "ab80126e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "E0000 00:00:1759930191.033656  892730 alts_credentials.cc:93] ALTS creds ignored. Not running on GCP and untrusted ALTS is not enabled.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "==================================\u001b[1m Ai Message \u001b[0m==================================\n",
+      "\n",
+      "Te llamas Juan. ¡Un placer conocerte, Juan! ¿En qué puedo ayudarte hoy?\n"
+     ]
+    }
+   ],
+   "source": [
+    "from langchain.chat_models import init_chat_model\n",
+    "\n",
+    "llm = init_chat_model(\"gemini-2.0-flash-001\", temperature=0)\n",
+    "response = llm.invoke(history)\n",
+    "response.pretty_print()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b116b87d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c98873fc",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "lang-graph",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "langchain>=1.0.0a10",
+    "langchain-google-genai>=2.1.12",
     "langchain-google-vertexai>=2.1.2",
     "langgraph>=1.0.0a4",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -345,10 +345,34 @@ wheels = [
 ]
 
 [[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
 name = "forbiddenfruit"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e6/79/d4f20e91327c98096d605646bdc6a5ffedae820f38d378d3515c42ec5e60/forbiddenfruit-0.1.4.tar.gz", hash = "sha256:e3f7e66561a29ae129aac139a85d610dbf3dd896128187ed5454b6421f624253", size = 43756, upload-time = "2021-01-16T21:03:35.401Z" }
+
+[[package]]
+name = "google-ai-generativelanguage"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/35/af6c759bfde70386c741309df0cba6a1cb09b8bbd1d02c841df51f4c672d/google_ai_generativelanguage-0.7.0.tar.gz", hash = "sha256:207fed3089949e2e99f7cbd513e2d0ea5f2babdfa5a8f2f239c3ddffe6bd4297", size = 1475859, upload-time = "2025-09-02T15:39:53.46Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/e7/b670b2d5b53f18ae51d331283278595fea93a156ea79baf59d4098effaec/google_ai_generativelanguage-0.7.0-py3-none-any.whl", hash = "sha256:3241215c16e669f37054f6111c84cca50fdb7a8e10a62933b9e68086ce71eefe", size = 1394333, upload-time = "2025-09-02T15:39:06.14Z" },
+]
 
 [[package]]
 name = "google-api-core"
@@ -881,6 +905,7 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "langchain" },
+    { name = "langchain-google-genai" },
     { name = "langchain-google-vertexai" },
     { name = "langgraph" },
 ]
@@ -895,6 +920,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "langchain", specifier = ">=1.0.0a10" },
+    { name = "langchain-google-genai", specifier = ">=2.1.12" },
     { name = "langchain-google-vertexai", specifier = ">=2.1.2" },
     { name = "langgraph", specifier = ">=1.0.0a4" },
 ]
@@ -937,6 +963,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/14/8ba54f4d2c40e3528e511a106aa95e6625083fb42607f1dc6797ce32181e/langchain_core-1.0.0a6.tar.gz", hash = "sha256:8c6d60cae6d7e6c3e3555ad05a4e65d0ae8167a7ee7b40233663209b019ffeae", size = 617086, upload-time = "2025-10-02T03:01:27.997Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/65/83/b53010d854f76c4373f66bc05a3ea2b85644ddf928e5af7e41db5cc2f832/langchain_core-1.0.0a6-py3-none-any.whl", hash = "sha256:46bb8f5dfe3637cf5fa594a8e40ddd2d4fd1cb48559afaeeece0ea83bd715a22", size = 484625, upload-time = "2025-10-02T03:01:26.46Z" },
+]
+
+[[package]]
+name = "langchain-google-genai"
+version = "2.1.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filetype" },
+    { name = "google-ai-generativelanguage" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/38/8b3a71c729bd03e9eb0fd8bdb19e06a074c35bc2eaa61b1b9edfa863f38d/langchain_google_genai-2.1.12.tar.gz", hash = "sha256:4a98371e545eb97fcdf483086a4aebbb8eceeb9597ca5a9c4c35e92f4fbbd271", size = 77566, upload-time = "2025-09-17T01:27:11.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/8d/9dd9653e5414e73cae3480e5947bbbbd94ba7fa824efdf46e7ff2c0faef2/langchain_google_genai-2.1.12-py3-none-any.whl", hash = "sha256:4c07630419a8fbe7a2ec512c6dea68289663bfe7d5fae0ba431d2cd59a0d0880", size = 50746, upload-time = "2025-09-17T01:27:10.653Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This commit introduces a notebook demonstrating the practical usage of Google's Gemini models through the LangChain framework.

The example covers the following key points:
- Loading the `GOOGLE_API_KEY` from environment variables using `python-dotenv`.
- Initializing a specific Gemini model (`gemini-2.0-flash-lite-001`) via `ChatGoogleGenerativeAI`.
- Performing a simple invocation with a single prompt to verify the connection.
- Building a conversational chain with history using `SystemMessage`, `HumanMessage`, and `AIMessage` to test context-awareness.
- Demonstrating an alternative model initialization with the `init_chat_model` helper function.